### PR TITLE
Warmstart (#7)

### DIFF
--- a/src/BayesianOptimization.jl
+++ b/src/BayesianOptimization.jl
@@ -61,11 +61,14 @@ function BOpt(func, model, acquisition, modeloptimizer, lowerbounds, upperbounds
     acquisitionoptions = merge(defaultoptions(typeof(model), typeof(acquisition)),
                acquisitionoptions)
     maxiterations < lhs_iterations && @error("maxiterations = $maxiterations < lhs_iterations = $lhs_iterations")
+
+    current_optimum   = isempty(model.y) ? -Inf*Int(sense)           : Int(sense) * maximum(model.y)
+    current_optimizer = isempty(model.y) ? zero(float.(lowerbounds)) : model.x[:, argmax(model.y)]
     BOpt(func, sense, model, acquisition,
          acquisitionoptions,
          modeloptimizer, float.(lowerbounds), float.(upperbounds),
-         -Inf64*Int(sense), Array{Float64}(undef, length(lowerbounds)),
-         -Inf64*Int(sense), Array{Float64}(undef, length(lowerbounds)),
+         current_optimum, current_optimizer,
+         current_optimum, copy(current_optimizer),
          IterationCounter(0, 0, maxiterations),
          DurationCounter(now, maxduration, now, now + maxduration),
          NLopt.Opt(acquisitionoptions.method, length(lowerbounds)),

--- a/src/BayesianOptimization.jl
+++ b/src/BayesianOptimization.jl
@@ -2,7 +2,6 @@ module BayesianOptimization
 import NLopt, GaussianProcesses
 import GaussianProcesses: GPBase, GPE
 import ElasticPDMats: ElasticPDMat
-import ElasticArrays: ElasticArray
 using ForwardDiff, DiffResults, Random, Dates, SpecialFunctions, TimerOutputs
 export BOpt, ExpectedImprovement, ProbabilityOfImprovement, UpperConfidenceBound,
 ThompsonSamplingSimple, MutualInformation, boptimize!, MAPGPOptimizer, NoOptimizer,

--- a/src/models/gp.jl
+++ b/src/models/gp.jl
@@ -68,4 +68,3 @@ function optimizemodel!(gp::GPBase, options)
     ret == NLopt.FORCED_STOP && throw(InterruptException())
     fx, x, ret
 end
-

--- a/src/models/gp.jl
+++ b/src/models/gp.jl
@@ -10,7 +10,11 @@ dims(model::GPBase) = size(model.x)
 maxy(model::GPBase) = length(model.y) == 0 ? -Inf : maximum(model.y)
 update!(model::GPE{X,Y,M,K,P,D}, x, y) where {X,Y,M,K,P<:ElasticPDMat, D} = append!(model, x, y)
 function update!(model::GPE{X,Y,M,K,P,D}, x, y) where {X,Y,M,K,P,D}
-    GP.fit!(model, hcat(model.x, x), [model.y; y])
+    if isempty(y)
+        GP.fit!(model, model.x, model.y)
+    else
+        GP.fit!(model, hcat(model.x, x), [model.y; y])
+    end
 end
 
 mutable struct MAPGPOptimizer{NT} <: ModelOptimizer

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,3 +2,4 @@ using BayesianOptimization, GaussianProcesses
 using Test
 include("acquisitionfunctions.jl")
 include("branin.jl")
+include("warmstart.jl")

--- a/test/warmstart.jl
+++ b/test/warmstart.jl
@@ -23,7 +23,7 @@ model_premade = ElasticGPE(x_premade, y_premade,
                lhs_iterations = 10)
     boptimize!(opt)
 
-    @test opt.observed_optimum == maximum(Int(opt.sense) * opt.model.y)
+    @test opt.observed_optimum == minimum(Int(opt.sense) * opt.model.y)
 end
 
 # (#7)

--- a/test/warmstart.jl
+++ b/test/warmstart.jl
@@ -1,10 +1,12 @@
 ac = ExpectedImprovement()
 x_premade = rand(2, 10)*15.0 .- [5.0; 0.0]
-y_premade = [branin(x_premade[:, i], noiselevel=0) for i in 1:size(x_premade, 2)]
-model_premade = ElasticGPE(x_premade, y_premade,
-           MeanConst(-10.0),
-           SEArd([0., 0.], 5.),
-           -2.0)
+y_premade = -1 * [branin(x_premade[:, i], noiselevel=0) for i in 1:size(x_premade, 2)]
+
+model_premade = GPE(x_premade, y_premade,
+   MeanConst(-10.0),
+   SEArd([0., 0.], 5.),
+   -2.0)
+
 
 # (#7)
 @testset "Initial Sampling Tracking" begin
@@ -23,7 +25,8 @@ model_premade = ElasticGPE(x_premade, y_premade,
                lhs_iterations = 10)
     boptimize!(opt)
 
-    @test opt.observed_optimum == minimum(Int(opt.sense) * opt.model.y)
+    @test opt.observed_optimum == Int(opt.sense) * maximum(opt.model.y)
+    @test length(opt.model.y) == 10
 end
 
 # (#7)
@@ -40,8 +43,8 @@ end
                verbosity = Silent,
                lhs_iterations = 5)
 
-    @test opt.observed_optimum == maximum(Int(opt.sense) * y_premade)
-    @test opt.observed_optimizer == x_premade[argmax(Int(opt.sense) * y_premade)]
+    @test opt.observed_optimum   == Int(opt.sense) * maximum(y_premade)
+    @test opt.observed_optimizer == x_premade[:, argmax(y_premade)]
 end
 
 # (#7)
@@ -60,6 +63,7 @@ end
                lhs_iterations = 0)
     boptimize!(opt)
 
-    @test length(opt.x) == length(x_premade)
-    @test length(opt.y) == length(y_premade)
+    @test opt.acquisition.τ == maximum(y_premade)
+    @test length(opt.model.x) == length(x_premade)
+    @test length(opt.model.y) == length(y_premade)
 end

--- a/test/warmstart.jl
+++ b/test/warmstart.jl
@@ -1,0 +1,65 @@
+ac = ExpectedImprovement()
+x_premade = rand(2, 10)*15.0 .- [5.0; 0.0]
+y_premade = [branin(x_premade[:, i], noiselevel=0) for i in 1:size(x_premade, 2)]
+model_premade = ElasticGPE(x_premade, y_premade,
+           MeanConst(-10.0),
+           SEArd([0., 0.], 5.),
+           -2.0)
+
+# (#7)
+@testset "Initial Sampling Tracking" begin
+    opt = BOpt(x -> branin(x, noiselevel = 0),
+               ElasticGPE(2, mean = MeanConst(-10.),
+                          kernel = SEArd([0., 0.], 5.),
+                          logNoise = -2., capacity = 3000),
+               ac,
+               MAPGPOptimizer(every = 50, noisebounds = [-4, 3],
+                             kernbounds = [[-1, -1, 0], [4, 4, 10]],
+                             maxeval = 40),
+               [-5., 0.], [10., 15.],
+               maxiterations = 10,
+               sense = Min,
+               verbosity = Silent,
+               lhs_iterations = 10)
+    boptimize!(opt)
+
+    @test opt.observed_optimum == maximum(Int(opt.sense) * opt.model.y)
+end
+
+# (#7)
+@testset "Pre-made model" begin
+    opt = BOpt(x -> branin(x, noiselevel = 0),
+               model_premade,
+               ac,
+               MAPGPOptimizer(every = 50, noisebounds = [-4, 3],
+                             kernbounds = [[-1, -1, 0], [4, 4, 10]],
+                             maxeval = 40),
+               [-5., 0.], [10., 15.],
+               maxiterations = 10,
+               sense = Min,
+               verbosity = Silent,
+               lhs_iterations = 5)
+
+    @test opt.observed_optimum == maximum(Int(opt.sense) * y_premade)
+    @test opt.observed_optimizer == x_premade[argmax(Int(opt.sense) * y_premade)]
+end
+
+# (#7)
+@testset "LHS Iterations to 0 on pre-made model" begin
+    ac = ExpectedImprovement()
+    opt = BOpt(x -> branin(x, noiselevel = 0),
+               model_premade,
+               ac,
+               MAPGPOptimizer(every = 50, noisebounds = [-4, 3],
+                             kernbounds = [[-1, -1, 0], [4, 4, 10]],
+                             maxeval = 40),
+               [-5., 0.], [10., 15.],
+               maxiterations = 0,
+               sense = Min,
+               verbosity = Silent,
+               lhs_iterations = 0)
+    boptimize!(opt)
+
+    @test length(opt.x) == length(x_premade)
+    @test length(opt.y) == length(y_premade)
+end


### PR DESCRIPTION
This addresses #7 and allows for warm-starting optimizations.

It's important to note that if the user wants to warm-start a model of a function that they seek to minimize, the values that populate that model should be set to -1 * the function returns, in order to agree with what `BayesianOptimization` uses internally.

This also tracks the optimizing points during LHS (or model initialization).